### PR TITLE
Enable Heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: mix phoenix.server

--- a/brunch-config.js
+++ b/brunch-config.js
@@ -61,23 +61,6 @@ exports.config = {
     }
   },
 
-  overrides: {
-    production: {
-      plugins: {
-        // babel: {
-        //   // Do not use ES6 compiler in vendor code
-        //   ignore: [/web\/static\/vendor/, /web\/static\/elm/]
-        // },
-        elmBrunch: null
-        // elmBrunch: {
-        //   elmFolder: 'web/elm',
-        //   mainModules: ['Main.elm'],
-        //   outputFolder: '../static/vendor'
-        // }
-      }
-    }
-  },
-
   modules: {
     autoRequire: {
       "js/app.js": ["web/static/js/app"]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "babel-brunch": "~6.0.0",
     "elm-brunch": "^0.4.4",
+    "elm": "~0.17.1",
     "brunch": "~2.1.3",
     "clean-css-brunch": "~1.8.0",
     "css-brunch": "~1.7.0",


### PR DESCRIPTION
### Changes
- The original error was caused by `elm` not being available. One way to install `elm` is via npm, which we are already using as phoenix uses this. E.g. by simply adding `elm` as a dependency in `package.json` we install elm.
- We also need a `Procfile` to tell Heroku how to start our main web process
- The attempt to not run elm by adding an override in brunch had to be removed, or the build fails.
### Heroku settings
- As outlined in http://www.phoenixframework.org/docs/heroku we use the following buildpacks in order: `https://github.com/HashNuke/heroku-buildpack-elixir.git`, `https://github.com/gjaldon/phoenix-static-buildpack`
- `MIX_ENV` environment variable may optionally be set (`prod` is the default)
- The app wants `POOL_SIZE`, `SECRET_KEY_BASE` and `DATABASE_URL` environment variables to be set.
